### PR TITLE
IACS-353 comment out unnecessary assertion

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -3156,9 +3156,9 @@ type patchConverter struct {
 func (pc *patchConverter) addPatchValueToDiff(
 	path []interface{}, v, old, newInput, oldInput interface{}, inArray bool,
 ) error {
-	contract.Assertf(v != nil || old != nil || oldInput != nil,
-		"path: %+v  |  v: %+v  | old: %+v  |  oldInput: %+v",
-		path, v, old, oldInput)
+	// contract.Assertf(v != nil || old != nil || oldInput != nil,
+	// 	"path: %+v  |  v: %+v  | old: %+v  |  oldInput: %+v",
+	// 	path, v, old, oldInput)
 
 	// If there is no new input, then the only possible diff here is a delete. All other diffs must be diffs between
 	// old and new properties that are populated by the server. If there is also no old input, then there is no diff


### PR DESCRIPTION
## 概要

対象チケット：https://m-pipe.atlassian.net/browse/IACS-353

Pulumiでリソースをデプロイ後に手動でとあるフィールドを削除し、Manifestからも該当のフィールドを削除した際に再度PulumiでデプロイするとPanicを起こしてしまう問題を回避するために、Panicを引き起こすAssertionをコメントアウトしました。
https://github.com/pulumi/pulumi-kubernetes/pull/2332 の修正によって、上記のケースでAssertionに引っ掛かるようになってしまったのが原因のようです。（おそらく考慮漏れ）
Assertionをスキップすることによって、今回のケースで期待する動作（no diff）になることは確認済みです。
- https://www.notion.so/nttcom/Deployment-Worker-ce4d78d5821a4cc2b7daa7c82aaec630